### PR TITLE
Improve deployment experience

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -11,5 +11,4 @@ for handler in app.logger.handlers:
 
 
 import server.api
-import server.submit_loop
 import server.views

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,7 +1,5 @@
 import logging
-import threading
 
-import werkzeug.serving
 from flask import Flask
 
 
@@ -15,8 +13,3 @@ for handler in app.logger.handlers:
 import server.api
 import server.submit_loop
 import server.views
-
-
-if not werkzeug.serving.is_running_from_reloader():
-    threading.Thread(target=server.submit_loop.run_loop, daemon=True).start()
-    # FIXME: Don't use daemon=True, exit from the thread properly

--- a/server/database.py
+++ b/server/database.py
@@ -11,7 +11,12 @@ from flask import g
 from server import app
 
 
-db_filename = os.path.join(os.path.dirname(__file__), 'flags.sqlite')
+schema_path = os.path.join(os.path.dirname(__file__), 'schema.sql')
+
+if "FLAGS_DATABASE" in os.environ:
+    db_filename = os.environ["FLAGS_DATABASE"]
+else:
+    db_filename = os.path.join(os.path.dirname(__file__), 'flags.sqlite')
 
 
 _init_started = False
@@ -20,7 +25,7 @@ _init_lock = threading.RLock()
 
 def _init(database):
     app.logger.info('Creating database schema')
-    with app.open_resource('schema.sql', 'r') as f:
+    with app.open_resource(schema_path, 'r') as f:
         database.executescript(f.read())
 
 

--- a/server/reloader.py
+++ b/server/reloader.py
@@ -1,13 +1,22 @@
 import importlib
 import os
 import threading
+import importlib.util
 
-from server import app, config as config_module
+from server import app
 
 
 _config_mtime = None
 _reload_lock = threading.RLock()
 
+if "CONFIG" in os.environ:
+    config_path = os.environ["CONFIG"]
+else:
+    config_path = os.path.join(app.root_path, 'config.py')
+
+config_spec = importlib.util.spec_from_file_location("server.config", config_path)
+config_module = importlib.util.module_from_spec(config_spec)
+config_spec.loader.exec_module(config_module)
 _cur_config = config_module.CONFIG
 
 
@@ -24,12 +33,12 @@ def get_config():
 
     global _config_mtime, _cur_config
 
-    cur_mtime = os.stat(os.path.join(app.root_path, 'config.py')).st_mtime_ns
+    cur_mtime = os.stat(config_path).st_mtime_ns
     if cur_mtime != _config_mtime:
         with _reload_lock:
             if cur_mtime != _config_mtime:
                 try:
-                    importlib.reload(config_module)
+                    config_spec.loader.exec_module(config_module)
                     _cur_config = config_module.CONFIG
                     app.logger.info('New config loaded')
                 except Exception as e:

--- a/server/standalone.py
+++ b/server/standalone.py
@@ -1,0 +1,11 @@
+import threading
+import werkzeug.serving
+
+
+from server import app
+import server.submit_loop
+
+
+if not werkzeug.serving.is_running_from_reloader():
+    threading.Thread(target=server.submit_loop.run_loop, daemon=True).start()
+    # FIXME: Don't use daemon=True, exit from the thread properly

--- a/server/start_server.sh
+++ b/server/start_server.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
+#!/bin/sh
 
 # Use FLASK_DEBUG=True if needed
 
-FLASK_APP=__init__.py python3 -m flask run --host 0.0.0.0 --with-threads
+FLASK_APP=standalone.py python3 -m flask run --host 0.0.0.0 --with-threads

--- a/server/submit_loop.py
+++ b/server/submit_loop.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import importlib
 import random
 import time
@@ -85,3 +87,7 @@ def run_loop():
         submit_spent = time.time() - submit_start_time
         if config['SUBMIT_PERIOD'] > submit_spent:
             time.sleep(config['SUBMIT_PERIOD'] - submit_spent)
+
+
+if __name__ == "__main__":
+    run_loop()


### PR DESCRIPTION
During Ugra CTF 2020 Finals we deployed DestructiveFarm using a custom NixOS module. When deployed this way it's needed to specify an external path to the configuration module and to the database, as the farm directory itself is read-only. We also needed a way to launch submit loop separately -- we used uWSGI for the farm itself and systemd for the submit loop process.

We tried to avoid any changes to the existing experience -- the simple "clone and run" use case should still be supported.