### PR TITLE
Run from any directory or by link, delete old DB before run

### DIFF
--- a/server/start_server.sh
+++ b/server/start_server.sh
@@ -2,5 +2,4 @@
 
 # Use FLASK_DEBUG=True if needed
 
-rm $(dirname $(readlink -f $0))/flags.sqlite
 FLASK_APP=$(dirname $(readlink -f $0))/standalone.py python3 -m flask run --host 0.0.0.0 --with-threads

--- a/server/start_server.sh
+++ b/server/start_server.sh
@@ -2,4 +2,5 @@
 
 # Use FLASK_DEBUG=True if needed
 
-FLASK_APP=standalone.py python3 -m flask run --host 0.0.0.0 --with-threads
+rm $(dirname $(readlink -f $0))/flags.sqlite
+FLASK_APP=$(dirname $(readlink -f $0))/standalone.py python3 -m flask run --host 0.0.0.0 --with-threads


### PR DESCRIPTION
With these changes it is possible to run the server from any location by executing `path/to/server/start_server.sh` or create a link to the file and start a server with it.
Also, now this file removes old flag database.